### PR TITLE
test: fix solidity test coverage

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,5 +1,5 @@
 module.exports = {
-	norpc: false, 
-	compileCommand: 'truffle compile', 
-	testCommand: 'export ETHEREUM_RPC_PORT=8555&& truffle test --network coverage --timeout 10000', 
+	norpc: false,
+	testCommand: 'node --max-old-space-size=4096 ../node_modules/.bin/truffle test --network coverage --timeout 10000',
+	compileCommand: 'node --max-old-space-size=4096 ../node_modules/.bin/truffle compile --network coverage'
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "solium:fix": "solium -d contracts --fix",
     "lint": "eslint ./test",
     "lint:fix": "eslint ./test --fix",
-    "coverage": "solidity-coverage",
+    "coverage": "SOLIDITY_COVERAGE=true ./node_modules/.bin/solidity-coverage",
     "gas-analysis": "truffle test ./benchmark/EcGasHelper.sol ./benchmark/gas.js"
   },
   "devDependencies": {

--- a/test/ellipticCurve.js
+++ b/test/ellipticCurve.js
@@ -1,10 +1,17 @@
+const SOLIDITY_COVERAGE = process.env.SOLIDITY_COVERAGE
 const EllipticCurve = artifacts.require("./TestEllipticCurve")
 
 contract("EllipticCurve", accounts => {
   // /////////////////////////////////////////// //
   // Check auxiliary operations for given curves //
   // /////////////////////////////////////////// //
-  const auxCurves = ["secp256k1", "P256"]
+  let auxCurves
+  if (SOLIDITY_COVERAGE) {
+    auxCurves = ["secp256k1"]// "secp256k1", "secp192k1", "secp224k1", "P256", "P192", "P224"]
+  } else {
+    auxCurves = ["secp256k1", "P256"]
+  }
+
   for (const curve of auxCurves) {
     describe(`Aux. operations - Curve ${curve}`, () => {
       const curveData = require(`./data/${curve}-aux.json`)
@@ -21,7 +28,7 @@ contract("EllipticCurve", accounts => {
       // toAffine
       for (const [index, test] of curveData.toAffine.valid.entries()) {
         it(`should convert a Jacobian point to affine (${index + 1})`, async () => {
-          const affine = await ecLib.toAffine(
+          const affine = await ecLib.toAffine.call(
             web3.utils.toBN(test.input.x),
             web3.utils.toBN(test.input.y),
             web3.utils.toBN(test.input.z),
@@ -37,7 +44,7 @@ contract("EllipticCurve", accounts => {
       // invMod
       for (const [index, test] of curveData.invMod.valid.entries()) {
         it(`should invert a scalar (${index + 1}) - ${test.description}`, async () => {
-          const inv = await ecLib.invMod(
+          const inv = await ecLib.invMod.call(
             web3.utils.toBN(test.input.k),
             pp,
           )
@@ -49,7 +56,7 @@ contract("EllipticCurve", accounts => {
       for (const [index, test] of curveData.invMod.invalid.entries()) {
         it(`should fail when inverting with invalid inputs (${index + 1}) - ${test.description}`, async () => {
           try {
-            await ecLib.invMod(
+            await ecLib.invMod.call(
               web3.utils.toBN(test.input.k),
               web3.utils.toBN(test.input.mod),
             )
@@ -62,7 +69,7 @@ contract("EllipticCurve", accounts => {
       // deriveY
       for (const [index, test] of curveData.deriveY.valid.entries()) {
         it(`should decode coordinate y from compressed point (${index + 1})`, async () => {
-          const coordY = await ecLib.deriveY(
+          const coordY = await ecLib.deriveY.call(
             web3.utils.hexToBytes(test.input.sign),
             web3.utils.hexToBytes(test.input.x),
             aa,
@@ -77,7 +84,7 @@ contract("EllipticCurve", accounts => {
       for (const [index, test] of curveData.isOnCurve.valid.entries()) {
         it(`should identify if point is on the curve (${index + 1}) - ${test.output.isOnCurve}`, async () => {
           assert.equal(
-            await ecLib.isOnCurve(
+            await ecLib.isOnCurve.call(
               web3.utils.hexToBytes(test.input.x),
               web3.utils.hexToBytes(test.input.y),
               aa,
@@ -91,7 +98,7 @@ contract("EllipticCurve", accounts => {
       // invertPoint
       for (const [index, test] of curveData.invertPoint.valid.entries()) {
         it(`should invert an EC point (${index + 1})`, async () => {
-          const invertedPoint = await ecLib.ecInv(
+          const invertedPoint = await ecLib.ecInv.call(
             web3.utils.hexToBytes(test.input.x),
             web3.utils.hexToBytes(test.input.y),
             pp
@@ -108,7 +115,13 @@ contract("EllipticCurve", accounts => {
   // /////////////////////////////////////////////// //
   // Check EC arithmetic operations for given curves //
   // /////////////////////////////////////////////// //
-  const curves = ["secp256k1", "secp192k1", "secp224k1", "P256", "P192", "P224"]
+  let curves
+  if (SOLIDITY_COVERAGE) {
+    curves = ["secp256k1"]
+  } else {
+    curves = ["secp256k1", "secp192k1", "secp224k1", "P256", "P192", "P224"]
+  }
+
   for (const curve of curves) {
     describe(`Arithmetic operations - Curve ${curve}`, () => {
       const curveData = require(`./data/${curve}.json`)
@@ -124,7 +137,7 @@ contract("EllipticCurve", accounts => {
       // Addition
       for (const [index, test] of curveData.addition.valid.entries()) {
         it(`should add two numbers (${index + 1}) - ${test.description}`, async () => {
-          const res = await ecLib.ecAdd(
+          const res = await ecLib.ecAdd.call(
             web3.utils.toBN(test.input.x1),
             web3.utils.toBN(test.input.y1),
             web3.utils.toBN(test.input.x2),
@@ -142,7 +155,7 @@ contract("EllipticCurve", accounts => {
       // Subtraction
       for (const [index, test] of curveData.subtraction.valid.entries()) {
         it(`should subtract two numbers (${index + 1}) - ${test.description}`, async () => {
-          const res = await ecLib.ecSub(
+          const res = await ecLib.ecSub.call(
             web3.utils.toBN(test.input.x1),
             web3.utils.toBN(test.input.y1),
             web3.utils.toBN(test.input.x2),
@@ -160,7 +173,7 @@ contract("EllipticCurve", accounts => {
       // Multiplication
       for (const [index, test] of curveData.multiplication.valid.entries()) {
         it(`should multiply EC points (${index + 1}) - ${test.description}`, async () => {
-          const res = await ecLib.ecMul(
+          const res = await ecLib.ecMul.call(
             web3.utils.toBN(test.input.k),
             web3.utils.toBN(test.input.x),
             web3.utils.toBN(test.input.y),

--- a/test/fastEcMul.js
+++ b/test/fastEcMul.js
@@ -1,7 +1,13 @@
+const SOLIDITY_COVERAGE = process.env.SOLIDITY_COVERAGE
 const EllipticCurve = artifacts.require("./TestEllipticCurve")
 
 contract("FastEcMul", accounts => {
-  const curves = ["secp256k1", "secp192k1", "secp224k1", "P256", "P192", "P224"]
+  let curves
+  if (SOLIDITY_COVERAGE) {
+    curves = ["secp256k1"]
+  } else {
+    curves = ["secp256k1", "secp192k1", "secp224k1", "P256", "P192", "P224"]
+  }
   for (const curve of curves) {
     describe(`Arithmetic operations - Curve ${curve}`, () => {
       const curveData = require(`./data/${curve}.json`)
@@ -20,7 +26,7 @@ contract("FastEcMul", accounts => {
       // Scalar decomposition
       for (const [index, test] of curveData.decomposeScalar.valid.entries()) {
         it(`should decompose an scalar (${index + 1}) - ${test.description}`, async () => {
-          const res = await fastEcMul.decomposeScalar(
+          const res = await fastEcMul.decomposeScalar.call(
             web3.utils.toBN(test.input.k),
             nn,
             lambda)
@@ -34,7 +40,7 @@ contract("FastEcMul", accounts => {
       // Simultaneous multiplication
       for (const [index, test] of curveData.simMul.valid.entries()) {
         it(`should do a simultaneous multiplication (${index + 1}) - ${test.description}`, async () => {
-          const res = await fastEcMul.ecSimMul(
+          const res = await fastEcMul.ecSimMul.call(
             [
               web3.utils.toBN(test.input.k1),
               web3.utils.toBN(test.input.k2),
@@ -61,15 +67,15 @@ contract("FastEcMul", accounts => {
       // MulAddMul
       for (const [index, test] of curveData.mulAddMul.valid.entries()) {
         it(`should do decompose scalar and simult. multiplication (${index + 1}) - ${test.description}`, async () => {
-          const k = await fastEcMul.decomposeScalar(
+          const k = await fastEcMul.decomposeScalar.call(
             web3.utils.toBN(test.input.k),
             nn,
             lambda)
-          const l = await fastEcMul.decomposeScalar(
+          const l = await fastEcMul.decomposeScalar.call(
             web3.utils.toBN(test.input.l),
             nn,
             lambda)
-          const res = await fastEcMul.ecSimMul(
+          const res = await fastEcMul.ecSimMul.call(
             [
               web3.utils.toBN(k[0]),
               web3.utils.toBN(k[1]),


### PR DESCRIPTION
This PR fixes the solidity coverage tests.

Problem: 

- Apparently, as we significantly increased the number of tests of this library, the logs to be processed by `solidity-coverage` were too big.
- The error was: `javascript heap out of memory`.

Workaround: 

- For code coverage check it is not required to test all the curves (we were testing 6 curves).
- We included a environment variable to check if the tests were for code coverage.
- If so, only the `secp256k1` curve is tested.

Notes:

- The `solidity-coverage` documentation provides some complex project examples that use their library, e.g. (OpenZeppelin Contracts)[https://github.com/OpenZeppelin/openzeppelin-contracts].
- Those projects uses `solidity-coverage` as follows:
  - A forked `ganache-cli` (ganache-cli-coverage)[https://github.com/frangio/ganache-cli/releases/download/v6.4.1-coverage/ganache-cli-coverage-6.4.1.tgz].
  - A `test.sh` bash scripts to handle the ganache lifecycle, callinng the aforementioned `ganache-cli-coverage` with the following arguments: `--emitFreeLogs true --allowUnlimitedContractSize true --gasLimit 0xfffffffffffff --port <port>" > /dev/null &`.



