### PR TITLE
perf: cache output of sqrt(nn)

### DIFF
--- a/contracts/FastEcMul.sol
+++ b/contracts/FastEcMul.sol
@@ -29,7 +29,10 @@ library FastEcMul {
     r[0] = uint256(_lambda);
     r[1] = uint256(_nn);
 
-    while (uint256(r[0]) >= _sqrt(_nn)) {
+    // Reuse variables because stack is not cheap
+    uint[3] memory test;
+    test[0] = _sqrt(_nn);
+    while (uint256(r[0]) >= test[0]) {
       uint256 quotient = r[1] / r[0];
       (r[1], r[0]) = (r[0], r[1] - quotient*r[0]);
       (t[1], t[0]) = (t[0], t[1] - int256(quotient)*t[0]);
@@ -43,7 +46,6 @@ library FastEcMul {
     ab[3] = 0 - t[1];
 
     //b2*K
-    uint[3] memory test;
     (test[0],test[1], test[2]) = _multiply256(uint(ab[3]), uint(k));
 
     //-b1*k


### PR DESCRIPTION
Because nn is constant. It reuses a variable to avoid increasing the stack size, just pretend that instead of `test[0]` you see `sqrt_nn`.

The only affected method is _decomposeScalar, where the improvement is from 937567 average gas used to 73016 (12x).

Output of `yarn gas-analysis`:

Old:
```
········································|···························|·············|·····························
|  Methods                              ·               20 gwei/gas               ·       213.25 usd/eth       │
··················|·····················|·············|·············|·············|··············|··············
|  Contract       ·  Method             ·  Min        ·  Max        ·  Avg        ·  # calls     ·  usd (avg)  │
··················|·····················|·············|·············|·············|··············|··············
|  EcGasHelper    ·  _decomposeScalar   ·     653611  ·    1078579  ·     937567  ·         134  ·       4.00  │
··················|·····················|·············|·············|·············|··············|··············
```
New:
```
········································|···························|·············|·····························
|  Methods                              ·               20 gwei/gas               ·       212.91 usd/eth       │
··················|·····················|·············|·············|·············|··············|··············
|  Contract       ·  Method             ·  Min        ·  Max        ·  Avg        ·  # calls     ·  usd (avg)  │
··················|·····················|·············|·············|·············|··············|··············
|  EcGasHelper    ·  _decomposeScalar   ·      65071  ·      78215  ·      73016  ·         134  ·       0.31  │
··················|·····················|·············|·············|·············|··············|··············
```