### PR TITLE
fix : a minor typo in helpers function of EllipticCurve.sol

### DIFF
--- a/contracts/EllipticCurve.sol
+++ b/contracts/EllipticCurve.sol
@@ -129,7 +129,7 @@ library EllipticCurve {
     {
         require(
             _prefix == 0x02 || _prefix == 0x03,
-            "EllipticCurve:innvalid compressed EC point prefix"
+            "EllipticCurve:invalid compressed EC point prefix"
         );
 
         // x^3 + ax + b
@@ -236,7 +236,7 @@ library EllipticCurve {
         return toAffine(x, y, z, _pp);
     }
 
-    /// @dev Substract two points (x1, y1) and (x2, y2) in affine coordinates.
+    /// @dev Subtract two points (x1, y1) and (x2, y2) in affine coordinates.
     /// @param _x1 coordinate x of P1
     /// @param _y1 coordinate y of P1
     /// @param _x2 coordinate x of P2
@@ -284,15 +284,15 @@ library EllipticCurve {
         return toAffine(x1, y1, z1, _pp);
     }
 
-    /// @dev Adds two points (x1, y1, z1) and (x2 y2, z2).
+    /// @dev Adds two points (x1, y1, z1) and (x2, y2, z2).
     /// @param _x1 coordinate x of P1
     /// @param _y1 coordinate y of P1
     /// @param _z1 coordinate z of P1
-    /// @param _x2 coordinate x of square
-    /// @param _y2 coordinate y of square
-    /// @param _z2 coordinate z of square
+    /// @param _x2 coordinate x of P2
+    /// @param _y2 coordinate y of P2
+    /// @param _z2 coordinate z of P2
     /// @param _pp the modulus
-    /// @return (qx, qy, qz) P1+square in Jacobian
+    /// @return (qx, qy, qz) P1+P2 in Jacobian
     function jacAdd(
             uint256 _x1,
             uint256 _y1,

--- a/contracts/FastEcMul.sol
+++ b/contracts/FastEcMul.sol
@@ -18,7 +18,7 @@ library FastEcMul {
     uint256 private constant U128_MAX = 340282366920938463463374607431768211455;
 
     /// @dev Decomposition of the scalar k in two scalars k1 and k2 with half bit-length, such that k=k1+k2*LAMBDA (mod n)
-    /// @param _k the scalar to be decompose
+    /// @param _k the scalar to be decomposed
     /// @param _nn the modulus
     /// @param _lambda is a root of the characteristic polynomial of an endomorphism of the curve
     /// @return k1 and k2  such that k=k1+k2*LAMBDA (mod n)
@@ -464,8 +464,8 @@ library FastEcMul {
     }
 
     /// @dev Division of an integer of 312 bits by a 256-bit integer.
-    /// @param _aM the higher 256 bits of the numarator
-    /// @param _am the lower 128 bits of the numarator
+    /// @param _aM the higher 256 bits of the numerator
+    /// @param _am the lower 128 bits of the numerator
     /// @param _b the 256-bit denominator
     /// @return q the result of the division and the rest r
     function _bigDivision(


### PR DESCRIPTION
Changed the revert statement typo and some more comments typo in one other file also contracts/EllipticCurve.sol , `contracts/FastEcMul.sol`

This closes #38  